### PR TITLE
Add central location for references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,36 @@ research groups, providing a reference frame for other code capabilities,
 and hosting external contributions.
 
 Benchmark problems are grouped by the program used to perform the simulation. For each problem included in the repository, the files required to run the case are included in an input_files directory, information about the latest run is contained in a run_info directory, and output data is compiled in a performance directory. Run information primarily includes the headers of log files, which capture the git hash/version recently used to run each specific example, and the footers of log files, which display profiling data and the number of time steps taken. Performance broadly includes both measured results from the simulation, such as physical quantities of interest, and computational timing information. README files provide synopses of each case and the resources used.
+
+# References
+
+To cite the cases and data from this repository, please use the following references (which contain the published versions of the cases and results):
+
+```
+@article{Sharma2024,
+    author = {Sharma, Ashesh and Brazell, Michael J. and Vijayakumar, Ganesh and Ananthan, Shreyas and Cheung, Lawrence and deVelder, Nathaniel and {Henry de Frahan}, Marc T. and Matula, Neil and Mullowney, Paul and Rood, Jon and Sakievich, Philip and Almgren, Ann and Crozier, Paul S. and Sprague, Michael},
+    title = {ExaWind: Open-source CFD for hybrid-RANS/LES geometry-resolved wind turbine simulations in atmospheric flows},
+    journal = {Wind Energy},
+    volume = {27},
+    number = {3},
+    pages = {225-257},
+    doi = {https://doi.org/10.1002/we.2886},
+    url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/we.2886},
+    eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/we.2886},
+    year = {2024}
+}
+
+@article{Bidadi2023},
+    author = {Shreyas Bidadi, Ganesh Vijayakumar, Ashesh Sharma and Michael A. Sprague},
+    title = {Mesh and model requirements for capturing deep-stall aerodynamics in low-Mach-number flows},
+    journal = {Journal of Turbulence},
+    volume = {24},
+    number = {8},
+    pages = {393--418},
+    year = {2023},
+    publisher = {Taylor \& Francis},
+    doi = {10.1080/14685248.2023.2225141},
+    URL = {https://doi.org/10.1080/14685248.2023.2225141},
+    eprint = {https://doi.org/10.1080/14685248.2023.2225141}
+}
+```


### PR DESCRIPTION
I want a central, easy to find/use location for the references that should be cited if people want to reference it.

@sbidadi9 and @BumseokLee can you make sure I captured your preferred reference correctly? I didn't see anything for `2D_airfoil_Transition` yet. I will let you create a separate PR if you like to adjust/add.