### PR TITLE
Change remote to Amazon S3 bucket

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,2 +1,4 @@
+[core]
+    remote = amazon
 ['remote "amazon"']
     url = http://exawind-datasets.s3.amazonaws.com/data/

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,2 @@
-[core]
-    remote = kestrel
-['remote "kestrel"']
-    url = ssh://gvijayak@kl3.hpc.nrel.gov:/projects/hfm/exawind-benchmark-meshes
+['remote "amazon"']
+    url = http://exawind-datasets.s3.amazonaws.com/data/


### PR DESCRIPTION
Could someone please try the new dvc remote and let me know? All you have to do to test it is


```
git clone --single-branch --branch change_remote git@github.com:gantech/exawind-benchmarks.git
cd exawind-benchmarks
dvc pull
```


If this works, then the pull request can be merged. This will make the mesh files accessible to the public.